### PR TITLE
add number of people & number of weeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,17 @@ A defualt CSV file that can contains a list of names to use as part of the roste
 ## Run script 
 You can run the script by using the command line and passing it the necessary arguments. As an example:
 
-`python roster.py names.csv 16-01-2023`
+`python roster.py  names.csv 01-01-2023 -w 4`
+This command will run the script, passing in the file path of the CSV file containing the names, the starting date in the format DD-MM-YYYY, the number of weeks to generate the roster for as 4, and the number of people to assign per week as 2 (the default value).
 
-This will execute the script with the names file 'names.csv' and start date " as parameters.
+You can also specify the number of people per week while running the script:
+
+`python roster.py names.csv 01-01-2023 -w 4 -n 3`
+
+This command will run the script, passing in the file path of the CSV file containing the names, the starting date in the format DD-MM-YYYY, the number of weeks to generate the roster for as 4, and the number of people to assign per week as 3.
+
+Please note that you have to provide the name of your script , the name of the csv file and the date in the format "DD-MM-YYYY" and the number of weeks.
+
 
 ```
 Week | Date       | Names
@@ -34,3 +42,6 @@ Week | Date       | Names
    2 | 23/01/2023 | Person3 and Person1
    3 | 30/01/2023 | Person4 and Person5
 ```
+
+## Limitations 
+As currently written, the script is limited by the number of names in the CSV file. If the number of weeks specified by the user exceeds the number of possible pairings, the roster generates the maximum number of possible pairings rather than raising an error.

--- a/roster.py
+++ b/roster.py
@@ -2,7 +2,7 @@ import argparse
 import csv
 import datetime
 
-def create_weekly_roster(names_file, start_date):
+def create_weekly_roster(names_file, start_date, num_people, num_weeks):
     #create an empty roster list
     roster = []
 
@@ -17,14 +17,16 @@ def create_weekly_roster(names_file, start_date):
 
     # create the weekly roster
     week_num = 1
-    for i in range(0, len(names), 2):
-        if i + 2 > len(names):
+    for i in range(0, len(names), num_people):
+        if i + num_people > len(names):
             roster.append((week_num, start_date, names[i:]))
             roster[week_num-1][2].append(names[0])
             names.pop(0)
         else:
-            roster.append((week_num, start_date, names[i:i+2]))
+            roster.append((week_num, start_date, names[i:i+num_people]))
         week_num += 1
+        if week_num > num_weeks:
+            break
         start_date += datetime.timedelta(days=7)
 
     return roster
@@ -33,14 +35,22 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("names_file", help="the file path of the CSV file containing the names to be added to the roster.")
     parser.add_argument("start_date", help="the starting date for the weekly roster in the format DD-MM-YYYY.")
+    parser.add_argument("-n", "--num_people", type=int, default=2, help="the number of people to assign per week.")
+    parser.add_argument("-w", "--num_weeks", type=int, help="the number of weeks to generate the roster for.")
     args = parser.parse_args()
-
+    
     #parse the start_date
     start_date = datetime.datetime.strptime(args.start_date, "%d-%m-%Y")
 
     # test the function
-    roster = create_weekly_roster(args.names_file, start_date)
-
+    try:
+        roster = create_weekly_roster(args.names_file, start_date, args.num_people, args.num_weeks)
+    except FileNotFoundError:
+        print("The file path provided does not exist.")
+        return
+    except ValueError:
+        print("The CSV file is empty.")
+        return
     # print the roster in a table format
     print("Week | Date       | Names")
     print("-----|------------|------")


### PR DESCRIPTION
- add an option to specify the number of people to assign per week, rather than always assigning 2.
- add an option to specify the number of weeks to generate the roster for.